### PR TITLE
Make edge function more reliable

### DIFF
--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -1,5 +1,4 @@
 import '../../src/env.js';
-import axios from 'axios';
 import { EleventyEdge, precompiledAppData } from './_generated/eleventy-edge-app.js';
 
 export default async (request, context) => {

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -1,4 +1,3 @@
-import '../../src/env.js';
 import { EleventyEdge, precompiledAppData } from './_generated/eleventy-edge-app.js';
 
 export default async (request, context) => {
@@ -18,8 +17,6 @@ export default async (request, context) => {
       // Make geo data available globally
       eleventyConfig.addGlobalData('geo', context.geo);
     });
-
-    // console.log(context.geo);
 
     return await edge.handleResponse();
   } catch (e) {

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -30,7 +30,7 @@ permalink:
           <h4 class="title">
             A photo from {{ photo.rover.name }}'s {{ photo.camera.full_name }} on Mars on sol {{ photo.sol }}
           </h4>
-          <div class="subtitle">Earth date {{ photo.earth_date }}, this day in 2021</div>
+          <div class="subtitle">Earth date {{ photo.earth_date }} UTC, this day in 2021</div>
           <img
             class="pix"
             src="{{ photo.img_src}}"

--- a/test/11ty-config.test.js
+++ b/test/11ty-config.test.js
@@ -14,4 +14,7 @@ test('Check input and output directories in 11ty config', () => {
   expect(config.addPassthroughCopy).toHaveBeenCalledTimes(2);
   // Make sure the addPlugin function was called properly
   expect(config.addPlugin).toHaveBeenCalledTimes(2);
+  // Make sure the addFilter function was called properly
+  expect(config.addFilter.mock.calls[0][0]).toBe('getNasaImage');
+  expect(config.addFilter).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
Originally, this PR was to remove the edge function entirely since it was unreliable. But removing the `axios` import seems to have fixed it.